### PR TITLE
#167130949 setup cancel-trip endpoint

### DIFF
--- a/src/controllers/buses.js
+++ b/src/controllers/buses.js
@@ -22,7 +22,6 @@ const Bus = {
       });
     } catch (ex) {
       if (ex) {
-        console.log('BUSE EXC: ', ex);
         return res.status(500).json({ status: 'Error', data: { message: ex.message } });
       }   
     }

--- a/src/controllers/trips.js
+++ b/src/controllers/trips.js
@@ -46,6 +46,44 @@ const Trip = {
     } catch (ex) {
       if (ex) return res.status(500).json({ status: 'Error', data: { message: ex.message } });
     }
+  },
+
+  /**
+     * request a given trip
+     * @param {object} req 
+     * @param {object} res 
+     */
+  async getTripById(req, res) {
+    try {
+      const { rows } = await tripModel.selectTripById(req.params.id);
+      if (!rows[0]) {
+        return res.status(404).json({ status: 'Error', data: { message: 'TRIP WITH GIVEN ID NOT FOUND' } });
+      }
+      return res.status(200).json({ status: 'SUCCESS', data: rows[0] });
+    } catch (ex) {
+      if (ex) return res.status(500).json({ status: 'Error', data: { message: ex.message } });
+    }
+  },  
+
+  /**
+   * update a trip
+   * @param {*} req 
+   * @param {*} res 
+   */
+  async cancelTrip(req, res) {
+    const { status } = req.body;
+
+    try {
+      const { rows } = await tripModel.selectTripById(req.params.id);
+      if (!rows[0]) {
+        return res.status(404).json({ status: 'Error', data: { message: 'Trip with given id not found' } });
+      }
+
+      await tripModel.updateTripStatusById(req.params.id, [status]);
+      return res.status(200).json({ status: 'SUCCESS', data: { message: 'Trip cancelled successfully' } });
+    } catch (ex) {
+      if (ex) return res.status(500).json({ status: 'Error', data: { message: ex.message } });
+    }
   }
 };
 

--- a/src/helpers/passwordHelper.js
+++ b/src/helpers/passwordHelper.js
@@ -1,28 +1,28 @@
 import bcrypt from 'bcrypt';
 
 const passwordHelper = {
-    /**
+  /**
      * hash a password
      * @param {String} password 
      * @returns{String} hashed password
      */
 
-    hashPassword(password) {
-        const salt = bcrypt.genSaltSync(12);
-        return bcrypt.hashSync(password, salt);
-    },
+  hashPassword(password) {
+    const salt = bcrypt.genSaltSync(12);
+    return bcrypt.hashSync(password, salt);
+  },
 
-    /**
+  /**
      * compare password
      * @param {String} password
      * @param {String} hashedPassword
      * @returns {Boolean}
      */
 
-    comparePassword (password, hashedPassword) {
-        return bcrypt.compareSync(password, hashedPassword);         
-    }
-}
+  comparePassword(password, hashedPassword) {
+    return bcrypt.compareSync(password, hashedPassword);         
+  }
+};
 
 
 export default passwordHelper;

--- a/src/models/trip.js
+++ b/src/models/trip.js
@@ -21,6 +21,32 @@ const tripModel = {
     return pool.query(
       'SELECT * FROM trips ORDER BY id ASC'
     );
+  },
+
+  /**
+   * select trip with id
+   * @param {string || number} id 
+   */
+  selectTripById(id) {
+    return pool.query(
+      'SELECT * FROM trips WHERE id = $1', 
+      [id]
+    );
+  },
+  
+
+  /**
+   * select trip update
+   * @param {string} id 
+   * @param {object} trip 
+   */
+  updateTripStatusById(id, trip) {
+    return pool.query(
+      `UPDATE trips SET 
+           status = $1 
+          WHERE id = $2 RETURNING *`,
+      [...Object.values(trip), id]
+    );
   }
 };
 

--- a/src/routes/trips.js
+++ b/src/routes/trips.js
@@ -7,4 +7,8 @@ export default function tripRoutes(app) {
   app.route('/api/v1/trips')
     .post([verifyToken, admin, validate(validateTrip)], Trip.postTrip)
     .get([verifyToken], Trip.getTrips);
+
+  app.route('/api/v1/trips/:id')
+    .get([verifyToken], Trip.getTripById)
+    .patch([verifyToken, admin], Trip.cancelTrip); 
 }

--- a/src/tests/adminTests.js
+++ b/src/tests/adminTests.js
@@ -20,6 +20,7 @@ const trip = {
   fare: 30.5
 };
 
+
 const bus = {
   number_plate: 'abc1',
   manufacturer: 'toyota',
@@ -59,8 +60,8 @@ describe('POST /trips endpoint', () => {
   it('should allow an Admin user access to create a trip', (done) => {
     chai.request(app)
       .post('/api/v1/trips')
-      .send(trip)
       .set('x-auth-token', token)
+      .send(trip)
       .end((err, res) => {
         assert.equal(res.status, 201);
         assert.typeOf(res.body, 'object');
@@ -69,3 +70,30 @@ describe('POST /trips endpoint', () => {
   });
 });
 
+describe('GET /trips/:id endpoint', () => {
+  it('should allow an Admin user access to view a particular trip', (done) => {
+    chai.request(app)
+      .get('/api/v1/trips/1')
+      .set('x-auth-token', token)
+      .end((err, res) => {
+        assert.equal(res.status, 200);
+        assert.typeOf(res.body, 'object');
+        done();
+      });
+  });
+});
+
+describe('PATCH /trips endpoint', () => {
+  it('should allow an Admin user access to CANCEL a trip', (done) => {
+    chai.request(app)
+      .patch('/api/v1/trips/1')
+      .set('x-auth-token', token)
+      .send({ status: 'cancelled' })
+      .end((err, res) => {
+        assert.equal(res.status, 200);
+        assert.typeOf(res.body, 'object');
+        assert.equal(res.body.data.message, 'Trip cancelled successfully');
+        done();
+      });
+  });
+});

--- a/src/tests/usersTest.js
+++ b/src/tests/usersTest.js
@@ -115,6 +115,20 @@ describe('GET /trips', () => {
       });
   });
 });
+describe('POST /buses endpoint', () => {
+  it('should not allow a user who is NOT AN ADMIN access to post a bus', (done) => {
+    chai.request(app)
+      .post('/api/v1/buses')
+      .send(bus)
+      .set('x-auth-token', token)
+      .end((err, res) => {
+        assert.equal(res.status, 403);
+        assert.typeOf(res.body, 'object');
+        assert.equal(res.body.data.message, 'ACCESS DENIED, YOU ARE NOT AN ADMIN');
+        done();
+      });
+  });
+});
 
 describe('POST /trips endpoint', () => {
   it('should not allow a user who is NOT AN ADMIN access to create a trip', (done) => {
@@ -131,12 +145,13 @@ describe('POST /trips endpoint', () => {
   });
 });
 
-describe('POST /buses endpoint', () => {
-  it('should not allow a user who is NOT AN ADMIN access to post a bus', (done) => {
+
+describe('PATCH /trips endpoint', () => {
+  it('should NOT ALLOW a user who is NOT an ADMIN access to CANCEL a trip', (done) => {
     chai.request(app)
-      .post('/api/v1/buses')
-      .send(bus)
+      .patch('/api/v1/trips/1')
       .set('x-auth-token', token)
+      .send({ status: 'cancelled' })
       .end((err, res) => {
         assert.equal(res.status, 403);
         assert.typeOf(res.body, 'object');


### PR DESCRIPTION
**What does this PR do?**
sets up an endpoint for admin to be able to cancel a trip

**Description of  task to be completed**
ensure that the following endpoints are returning the right response
GET /api/v1/trips/:id
PATCH /api/trips/:id

**How should this be tested manually?**
after cloning this repo, when an admin user makes a patch request to the  PATCH /api/v1/trips/:id endpoint, the admin should get a success response and if the user is not an admin, the user should get a 403 forbidden response

**what are the relevant pivotal tracker stories**
#167130949