### PR TITLE
#167233128 Add filter capability to get-trips endpoint

### DIFF
--- a/src/controllers/trips.js
+++ b/src/controllers/trips.js
@@ -41,9 +41,9 @@ const Trip = {
    */
   async getTrips(req, res) {
     try {
-      const { rows } = await tripModel.getAllTrips();
+      const { rows } = await tripModel.getAllTrips(req.query);
       return rows.length === 0
-        ? res.status(202).json({ message: 'No trip created yet' })
+        ? res.status(200).json({ message: 'No trip created yet' })
         : res.status(200).json({ status: 'success', data: rows });
     } catch (ex) {
       if (ex) return res.status(500).json({ status: 'error', data: { message: ex.message } });

--- a/src/models/trip.js
+++ b/src/models/trip.js
@@ -18,7 +18,21 @@ const tripModel = {
   /**
    * view all trips in the DB
    */
-  getAllTrips() {
+  getAllTrips(filter) {
+    if (filter.origin) {
+      return pool.query(
+        'SELECT * FROM trips WHERE origin = $1 ORDER BY trip_id ASC',
+        [filter.origin]
+      );
+    }
+    
+    if (filter.destination) {
+      return pool.query(
+        'SELECT * FROM trips WHERE destination = $1 ORDER BY trip_id ASC',
+        [filter.destination]
+      );
+    }
+
     return pool.query(
       'SELECT * FROM trips ORDER BY trip_id ASC'
     );

--- a/src/tests/usersTest.js
+++ b/src/tests/usersTest.js
@@ -115,7 +115,7 @@ describe('POST /auth/signin', () => {
   });
 });
 
-describe('GET /trips', () => {
+describe('GET /trips endpoint', () => {
   it('should grant a user access to view all trips', (done) => {
     chai.request(app)
       .get('/api/v1/trips')
@@ -127,6 +127,33 @@ describe('GET /trips', () => {
       });
   });
 });
+
+describe('FILTER GET /trips endpoint', () => {
+  it('should grant a user access to view all trips from the same on origin', (done) => {
+    chai.request(app)
+      .get('/api/v1/trips?origin=ilasa')
+      .set('x-auth-token', token)
+      .end((err, res) => {
+        assert.equal(res.status, 200);
+        assert.typeOf(res.body, 'object');
+        assert.equal(res.body.data[0].fare, 30.5);
+        done();
+      });
+  });
+
+  it('should grant a user access to view all trips headed to same destination', (done) => {
+    chai.request(app)
+      .get('/api/v1/trips?destination=agungu')
+      .set('x-auth-token', token)
+      .end((err, res) => {
+        assert.equal(res.status, 200);
+        assert.typeOf(res.body, 'object');
+        assert.equal(res.body.data[0].fare, 30.5);
+        done();
+      });
+  });
+});
+
 describe('POST /buses endpoint', () => {
   it('should not allow a user who is NOT AN ADMIN access to post a bus', (done) => {
     chai.request(app)


### PR DESCRIPTION
**What does this PR do?**
adds the capability for users to search trips from same origin or trips headed for same destination

**Desccription of task to be completed**
ensure  a get requests by the following search quries are working properly
GET  /api/v1/trips?origin=requestedOrigin
GET  /api/v1/trips?destination=requestedDestination

**How should this be manually tested**
after cloning this repo, when a user sends a request to the above endpoints + request.query, the user should get a sucess responseif the requested trip(s) to the origin or location exists

**What are the relevant pivotal tracker stories?**
#167233128